### PR TITLE
Fix static data loader

### DIFF
--- a/tstarbot/data/data_context.py
+++ b/tstarbot/data/data_context.py
@@ -5,8 +5,7 @@ from __future__ import division
 from __future__ import print_function
 
 from s2clientprotocol import sc2api_pb2 as sc_pb
-from pysc2.lib.data_raw import data_raw_3_16
-from pysc2.lib.data_raw import data_raw_4_0
+from pysc2.lib.data_raw import get_data_raw
 from pysc2.lib import TechTree
 
 from tstarbot.data.queue.build_command_queue import BuildCommandQueue
@@ -21,14 +20,13 @@ from tstarbot.data.pool.enemy_pool import EnemyPool
 from tstarbot.data.pool.scout_pool import ScoutPool
 from tstarbot.data.pool.opponent_pool import OppoPool
 
-
 class StaticData(object):
   def __init__(self, config):
     self._obs = None
     self._timestep = None
-    self._data_raw = data_raw_4_0
-
     self.game_version = '3.16.1'
+    self._data_raw = get_data_raw(self.game_version)
+
     if hasattr(config, 'game_version'):
       self.game_version = config.game_version
     self.TT = TechTree()


### PR DESCRIPTION
It seems like in [this commit](#https://github.com/Tencent/PySC2TencentExtension/commit/617b6855b5bc256001a31b553974e3c6d365b5c0#diff-1276b57335a4c839274df93394bf0280e9dda3e24fb6edeca589f71a9513be12
) PySC2 extension was changed in a way that is not compatible with the code: static data is no longer exposed as a local variable. Changing to reflect the new API.